### PR TITLE
Update to publish docker images on master/release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,11 +4,14 @@ workspace:
 
 pipeline:
   build:
-    image: ncatelli/golang:${GO_DOCKER_TAG}
+    image: ncatelli/golang:1.10.2-alpine3.7
     commands:
       - make
 
-matrix:
-  GO_DOCKER_TAG: 
-    - 1.9.6-alpine3.7
-    - 1.10.2-alpine3.7
+  docker:
+    image: plugins/docker
+    repo: packetfire/immigrant
+    auto_tag: true
+    secrets: [ docker_username, docker_password ]
+    when:
+      branch: master


### PR DESCRIPTION
# Introduction
This commit adds the ability to publish docker images automatically on tags and master.

# Linked Issues
resolves #25 

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

