### PR TITLE
Golang Version Bump and VSCode Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,68 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM golang:1
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
+# this user's GID/UID must match your local user UID/GID to avoid permission issues
+# with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
+# https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt, install packages and tools
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git iproute2 procps lsb-release \
+    #
+    # Install gocode-gomod
+    && go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && go build -o gocode-gomod github.com/stamblerre/gocode \
+    && mv gocode-gomod $GOPATH/bin/ \
+    #
+    # Install Go tools
+    && go get -u -v \
+        github.com/mdempsky/gocode \
+        github.com/uudashr/gopkgs/cmd/gopkgs \
+        github.com/ramya-rao-a/go-outline \
+        github.com/acroca/go-symbols \
+        github.com/godoctor/godoctor \
+        golang.org/x/tools/cmd/guru \
+        golang.org/x/tools/cmd/gorename \
+        github.com/rogpeppe/godef \
+        github.com/zmb3/gogetdoc \
+        github.com/haya14busa/goplay/cmd/goplay \
+        github.com/sqs/goreturns \
+        github.com/josharian/impl \
+        github.com/davidrjenni/reftools/cmd/fillstruct \
+        github.com/fatih/gomodifytags \
+        github.com/cweill/gotests/... \
+        golang.org/x/tools/cmd/goimports \
+        golang.org/x/lint/golint \
+        golang.org/x/tools/cmd/gopls \
+        github.com/alecthomas/gometalinter \
+        honnef.co/go/tools/... \
+        github.com/golangci/golangci-lint/cmd/golangci-lint \
+        github.com/mgechev/revive \
+        github.com/derekparker/delve/cmd/dlv 2>&1 \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /go/src

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/go
+{
+	"name": "Go",
+	"dockerFile": "Dockerfile",
+	"runArgs": [
+		// Uncomment the next line to use a non-root user. On Linux, this will prevent
+		// new files getting created as root, but you may need to update the USER_UID
+		// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
+		// "-u", "vscode",
+
+		"--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
+	],
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.gopath": ""
+	},
+	
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [
+		"ms-vscode.go"
+	]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: go
 sudo: true
 go:
-  - "1.11.x"
-
-env:
-  - GO111MODULE=on
+  - "1.13.x"
 
 install:
   - sudo apt-get install -y make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
-ARG BASEIMG="alpine:3.7"
-ARG BUILDIMG="golang:1.10.1-alpine3.7"
+ARG BASEIMG="alpine:3.10"
+ARG BUILDIMG="golang:1.13.4-alpine3.10"
 FROM $BUILDIMG as builder
 
-ENV GOPATH=/go
-ENV GIT_USER=PacketFire
-ENV SCM_PROVIDER=github.com
+ENV GOPATH=""
 ENV APP_NAME=immigrant
 
-COPY . /go/src/${SCM_PROVIDER}/${GIT_USER}/${APP_NAME}/
+COPY . /go/
 
-RUN cd ${GOPATH} && go build -o /${APP_NAME} ${SCM_PROVIDER}/${GIT_USER}/${APP_NAME}
+RUN cd /go && go build -o /${APP_NAME}
 
 FROM $BASEIMG
 LABEL maintainer="Nate Catelli <ncatelli@packetfire.org>"
 LABEL description="Container for immigrant"
 
 ENV SERVICE_USER "immigrant"
-ENV APP_NAME=immigrant
+ENV APP_NAME="immigrant"
 
 RUN addgroup ${SERVICE_USER} && \
     adduser -D -G ${SERVICE_USER} ${SERVICE_USER}

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/mitchellh/cli v1.0.0
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13


### PR DESCRIPTION
# Introduction
This PR adds a minimal devcontainer configuration for use with VSCode along with a version bump from golang 1.10 -> 1.13. Along with this version bump. This PR also begins to more heavily lean into go modules.

It's worth noting that the VSCode container doesn't currently have docker configured within it.

# Linked Issues
resolves #44 
resolves #39 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment

