### PR TITLE
Compatibility fixes and test improvements for Mock Driver

### DIFF
--- a/pkg/drivers/mock/mock.go
+++ b/pkg/drivers/mock/mock.go
@@ -56,4 +56,4 @@ func (dri *Driver) State() *core.Revision {
 // Close mocks the requirements for Close on the
 // github.com/PacketFire/immigrant/pkg/core.Driver interface. This method
 // simply functions as a noop.
-func Close() {}
+func (dri *Driver) Close() {}

--- a/pkg/drivers/mock/mock.go
+++ b/pkg/drivers/mock/mock.go
@@ -9,7 +9,7 @@ import (
 // Driver implements github.com/PacketFire/immigrant/pkg/core.Driver, storing
 // revisions to an in memory representation of the Revisions store.
 type Driver struct {
-	Revisions []core.Revision
+	Revisions []*core.Revision
 }
 
 // Init mocks the requirements for Init on the
@@ -23,7 +23,7 @@ func (dri *Driver) Init(config map[string]string) error {
 // github.com/PacketFire/immigrant/pkg/core.Driver interface. This method
 // appends the past Revision to an in memory store and returns a success.
 func (dri *Driver) Migrate(r core.Revision) error {
-	dri.Revisions = append(dri.Revisions, r)
+	dri.Revisions = append(dri.Revisions, &r)
 	return nil
 }
 
@@ -43,9 +43,14 @@ func (dri *Driver) Rollback(r core.Revision) error {
 // State mocks the requirements for State on the
 // github.com/PacketFire/immigrant/pkg/core.Driver interface. This method
 // retrieves the previous revision from the internal representation of the
-// revision map.
+// revision map. If the Revision list is empty, nil is returned.
 func (dri *Driver) State() *core.Revision {
-	return &dri.Revisions[len(dri.Revisions)-1]
+	rtl := len(dri.Revisions)
+	if rtl == 0 {
+		return nil
+	}
+
+	return dri.Revisions[rtl-1]
 }
 
 // Close mocks the requirements for Close on the

--- a/pkg/drivers/mock/mock_test.go
+++ b/pkg/drivers/mock/mock_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/PacketFire/immigrant/pkg/core"
 )
 
-var ec chan error
-var name string
-var this Driver
-
 func TestDriverMigrateMethodShould(t *testing.T) {
 	r := core.Revision{
 		Revision: "1-create-test-table",

--- a/pkg/drivers/mock/mock_test.go
+++ b/pkg/drivers/mock/mock_test.go
@@ -8,6 +8,19 @@ import (
 	"github.com/PacketFire/immigrant/pkg/core"
 )
 
+var errFmt string = "expected %v got %v"
+
+func TestDriverInitMethodShould(t *testing.T) {
+	t.Run("return nil", func(t *testing.T) {
+		var dri Driver
+		conf := make(map[string]string)
+
+		if rv := dri.Init(conf); rv != nil {
+			t.Errorf(errFmt, nil, rv)
+		}
+	})
+}
+
 func TestDriverMigrateMethodShould(t *testing.T) {
 	r := core.Revision{
 		Revision: "1-create-test-table",
@@ -21,7 +34,7 @@ func TestDriverMigrateMethodShould(t *testing.T) {
 
 		dri.Migrate(r)
 		if len(dri.Revisions) != 1 || !reflect.DeepEqual(*dri.Revisions[0], r) {
-			t.Errorf("expected %v got %v", r, *dri.Revisions[0])
+			t.Errorf(errFmt, r, *dri.Revisions[0])
 		}
 	})
 }
@@ -38,12 +51,12 @@ func TestDriverRollbackMethodShould(t *testing.T) {
 		dri.Revisions = []*core.Revision{&r}
 
 		if err := dri.Rollback(r); err != nil {
-			t.Errorf("expected %v got %v", nil, err)
+			t.Errorf(errFmt, nil, err)
 		}
 
 		rlen := len(dri.Revisions)
 		if rlen != 0 {
-			t.Errorf("expected %v got %v", 0, rlen)
+			t.Errorf(errFmt, 0, rlen)
 		}
 	})
 
@@ -52,7 +65,7 @@ func TestDriverRollbackMethodShould(t *testing.T) {
 		dri.Revisions = []*core.Revision{}
 
 		if err := dri.Rollback(r); err == nil {
-			t.Errorf("expected %v got %v", errors.New("no revisions applied"), err)
+			t.Errorf(errFmt, errors.New("no revisions applied"), err)
 		}
 	})
 }
@@ -69,7 +82,7 @@ func TestDriverStateMethodShould(t *testing.T) {
 		dri.Revisions = []*core.Revision{r}
 		sr := dri.State()
 		if !reflect.DeepEqual(*r, *sr) {
-			t.Errorf("expected %v got %v", *r, *sr)
+			t.Errorf(errFmt, *r, *sr)
 		}
 	})
 
@@ -78,7 +91,7 @@ func TestDriverStateMethodShould(t *testing.T) {
 		dri.Revisions = []*core.Revision{}
 		sr := dri.State()
 		if sr != nil {
-			t.Errorf("expected %v got %v", nil, sr)
+			t.Errorf(errFmt, nil, sr)
 		}
 	})
 }

--- a/pkg/drivers/mock/mock_test.go
+++ b/pkg/drivers/mock/mock_test.go
@@ -95,3 +95,11 @@ func TestDriverStateMethodShould(t *testing.T) {
 		}
 	})
 }
+
+func TestDriverCloseMethodShould(t *testing.T) {
+	t.Run("exist as a method", func(t *testing.T) {
+		var dri Driver
+
+		dri.Close()
+	})
+}

--- a/pkg/drivers/mock/mock_test.go
+++ b/pkg/drivers/mock/mock_test.go
@@ -47,7 +47,7 @@ func TestDriver_Rollback(t *testing.T) {
 	})
 }
 
-func DriverStateMethodShould(t *testing.T) {
+func TestDriverStateMethodShould(t *testing.T) {
 	r := &core.Revision{
 		Revision: "1-create-test-table",
 		Migrate:  []string{"create table test ( `id` int(11) not null, primary key (`id`));"},
@@ -67,8 +67,8 @@ func DriverStateMethodShould(t *testing.T) {
 		var dri Driver
 		dri.Revisions = []*core.Revision{}
 		sr := dri.State()
-		if !reflect.DeepEqual(*r, *sr) {
-			t.Errorf("expected %v got %v", *r, *sr)
+		if sr != nil {
+			t.Errorf("expected %v got %v", nil, sr)
 		}		
 	})
 }

--- a/pkg/drivers/mock/mock_test.go
+++ b/pkg/drivers/mock/mock_test.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -48,6 +49,15 @@ func TestDriverRollbackMethodShould(t *testing.T) {
 		rlen := len(dri.Revisions)
 		if rlen != 0 {
 			t.Errorf("expected %v got %v", 0, rlen)
+		}
+	})
+
+	t.Run("throw an error if a rollback is run against a driver with no state", func(t *testing.T) {
+		var dri Driver
+		dri.Revisions = []*core.Revision{}
+
+		if err := dri.Rollback(r); err == nil {
+			t.Errorf("expected %v got %v", errors.New("no revisions applied"), err)
 		}
 	})
 }

--- a/pkg/drivers/mock/mock_test.go
+++ b/pkg/drivers/mock/mock_test.go
@@ -30,19 +30,24 @@ func TestDriver_Migrate(t *testing.T) {
 	})
 }
 
-func TestDriver_Rollback(t *testing.T) {
-	name = "rollback"
-	rs := core.Revision{
+func TestDriverRollbackMethodShould(t *testing.T) {
+	r := core.Revision{
 		Revision: "1-create-test-table",
 		Migrate:  []string{"create table test ( `id` int(11) not null, primary key (`id`));"},
 		Rollback: []string{"drop table test"},
 	}
 
-	t.Run(name, func(t *testing.T) {
-		this.Rollback(rs)
+	t.Run("pop the most recent revision off of the in memory state if state exists", func(t *testing.T) {
+		var dri Driver
+		dri.Revisions = []*core.Revision{&r}
 
-		if len(this.Revisions) != 0 {
-			t.Log("failed")
+		if err := dri.Rollback(r); err != nil {
+			t.Errorf("expected %v got %v", nil, err)
+		}
+
+		rlen := len(dri.Revisions)
+		if rlen != 0 {
+			t.Errorf("expected %v got %v", 0, rlen)
 		}
 	})
 }
@@ -56,7 +61,7 @@ func TestDriverStateMethodShould(t *testing.T) {
 
 	t.Run("return latest revision when revision state exists", func(t *testing.T) {
 		var dri Driver
-		dri.Revisions = []*core.Revision{r,}
+		dri.Revisions = []*core.Revision{r}
 		sr := dri.State()
 		if !reflect.DeepEqual(*r, *sr) {
 			t.Errorf("expected %v got %v", *r, *sr)
@@ -69,6 +74,6 @@ func TestDriverStateMethodShould(t *testing.T) {
 		sr := dri.State()
 		if sr != nil {
 			t.Errorf("expected %v got %v", nil, sr)
-		}		
+		}
 	})
 }

--- a/pkg/drivers/mock/mock_test.go
+++ b/pkg/drivers/mock/mock_test.go
@@ -12,21 +12,20 @@ var ec chan error
 var name string
 var this Driver
 
-func TestDriver_Migrate(t *testing.T) {
-	name = "migrate"
-	rs := core.Revision{
+func TestDriverMigrateMethodShould(t *testing.T) {
+	r := core.Revision{
 		Revision: "1-create-test-table",
 		Migrate:  []string{"create table test ( `id` int(11) not null, primary key (`id`));"},
 		Rollback: []string{"drop table test"},
 	}
 
-	t.Run(name, func(t *testing.T) {
-		this.Migrate(rs)
+	t.Run("append a revision to the state when invoked", func(t *testing.T) {
+		var dri Driver
+		dri.Revisions = []*core.Revision{}
 
-		if len(this.Revisions) == 1 {
-			if !reflect.DeepEqual(this.Revisions[0], rs) {
-				t.Log("failed")
-			}
+		dri.Migrate(r)
+		if len(dri.Revisions) != 1 || !reflect.DeepEqual(*dri.Revisions[0], r) {
+			t.Errorf("expected %v got %v", r, *dri.Revisions[0])
 		}
 	})
 }

--- a/pkg/drivers/mock/mock_test.go
+++ b/pkg/drivers/mock/mock_test.go
@@ -47,25 +47,28 @@ func TestDriver_Rollback(t *testing.T) {
 	})
 }
 
-func TestDriver_State(t *testing.T) {
-	name = "state"
-	rs := core.Revision{
+func DriverStateMethodShould(t *testing.T) {
+	r := &core.Revision{
 		Revision: "1-create-test-table",
 		Migrate:  []string{"create table test ( `id` int(11) not null, primary key (`id`));"},
 		Rollback: []string{"drop table test"},
 	}
 
-	rs2 := core.Revision{
-		Revision: "2-create-test2-table",
-		Migrate:  []string{"create table test2 ( `id` int(11) not null, primary key (`id`));"},
-		Rollback: []string{"drop table test2"},
-	}
-
-	t.Run(name, func(t *testing.T) {
-		this.Migrate(rs)
-		this.Migrate(rs2)
-		if !reflect.DeepEqual(*this.State(), this.Revisions[len(this.Revisions)-1]) {
-			t.Log("failed")
+	t.Run("return latest revision when revision state exists", func(t *testing.T) {
+		var dri Driver
+		dri.Revisions = []*core.Revision{r,}
+		sr := dri.State()
+		if !reflect.DeepEqual(*r, *sr) {
+			t.Errorf("expected %v got %v", *r, *sr)
 		}
+	})
+
+	t.Run("return nil when revision state doesn't exist", func(t *testing.T) {
+		var dri Driver
+		dri.Revisions = []*core.Revision{}
+		sr := dri.State()
+		if !reflect.DeepEqual(*r, *sr) {
+			t.Errorf("expected %v got %v", *r, *sr)
+		}		
 	})
 }


### PR DESCRIPTION
# Introduction
This PR adds some compatibility, test and functionality improvements to make the mock driver both conform to the requirements defined by the Driver interface as well as better illustrate test intent for future improvements.

# Linked Issues
resolves #57 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

```
root@6d5ef3b94490:/workspaces/immigrant# make fmt lint test
test -z 
golint -set_exit_status ./...
go test -race -cover ./...
ok      github.com/PacketFire/immigrant (cached)        coverage: 0.0% of statements [no tests to run]
?       github.com/PacketFire/immigrant/command [no test files]
ok      github.com/PacketFire/immigrant/command/version (cached)        coverage: 40.0% of statements
ok      github.com/PacketFire/immigrant/pkg/config      (cached)        coverage: 69.6% of statements
ok      github.com/PacketFire/immigrant/pkg/core        (cached)        coverage: 80.3% of statements
?       github.com/PacketFire/immigrant/pkg/drivers     [no test files]
ok      github.com/PacketFire/immigrant/pkg/drivers/mock        (cached)        coverage: 100.0% of statements
?       github.com/PacketFire/immigrant/pkg/drivers/mysql       [no test files]
ok      github.com/PacketFire/immigrant/pkg/drivers/sqlite      (cached)        coverage: 36.2% of statements
```

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

